### PR TITLE
feat: Handle summary length and display errors

### DIFF
--- a/src/app/mega-summarizer/components/input-text-form/input-text-form.component.tsx
+++ b/src/app/mega-summarizer/components/input-text-form/input-text-form.component.tsx
@@ -8,15 +8,22 @@ import useSummaryFetcher from "./use-summary-fetcher";
 
 export default function InputTextForm() {
   const [inputText, setInputText] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const { setSummary } = useSummaryContext();
   const { fetchSummary } = useSummaryFetcher();
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    const summary = await fetchSummary(inputText);
+    const response = await fetchSummary(inputText);
 
-    setSummary?.(summary);
+    if (response.error) {
+      setError(response.error);
+      return;
+    }
+
+    setError(null);
+    setSummary?.(response.summary);
   };
 
   return (
@@ -38,6 +45,11 @@ export default function InputTextForm() {
           <i className="fas fa-arrow-right"></i>
         </RoundButton>
       </form>
+      {error && (
+        <p className="has-text-danger mt-2 is-size-7 is-family-primary">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/mega-summarizer/components/input-text-form/use-summary-fetcher.ts
+++ b/src/app/mega-summarizer/components/input-text-form/use-summary-fetcher.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 interface Return {
-  fetchSummary: (text: string) => Promise<string>;
+  fetchSummary: (text: string) => Promise<any>;
 }
 
 type UseSummaryFetcher = () => Return;
@@ -10,13 +10,20 @@ const useSummaryFetcher: UseSummaryFetcher = () => {
   const fetchSummary = async (text: string) => {
     try {
       const response = await axios.post("/api/summarize", { text });
-      const summary = response.data.summary.replace(/[",.'!:?()]/g, "");
 
-      return summary;
-    } catch (error) {
-      console.error("Failed to summarize text", error);
+      const summary = response.data.summary;
 
-      return "";
+      return {
+        summary,
+        error: null,
+      };
+    } catch (error: any) {
+      console.error(error.response.data.error.message);
+
+      return {
+        summary: "",
+        error: error.response.data.error.message,
+      };
     }
   };
 

--- a/src/pages/api/summarize.ts
+++ b/src/pages/api/summarize.ts
@@ -25,9 +25,18 @@ export default async function handler(
 
     const summary = gptResponse.choices[0].message.content?.trim();
 
-    res.status(200).json({ summary });
-  } catch (error) {
-    console.error("Failed to summarize text", error);
-    res.status(500).json({ error: "Failed to summarize text" });
+    const cleanedSummary =
+      summary?.toLowerCase().replace(/[^a-z\s]/gi, "") || "";
+
+    if (cleanedSummary!.split(" ").length != 5) {
+      throw new Error(
+        "There was a problem while generating the summary. Please try again. Sorry about that",
+      );
+    }
+
+    res.status(200).json({ summary: cleanedSummary });
+  } catch (error: any) {
+    console.error("Failed to summarize text: ", error.message);
+    res.status(500).json({ error: { message: error.message } });
   }
 }


### PR DESCRIPTION
This commit adds error handling for the case when the summary length exceeds 5 words. It also displays any errors on the frontend. The summary is now cleaned of non-alphanumeric characters and converted to lowercase before the length check.